### PR TITLE
feat: introduce Math.getRandomValues()

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ representation _(as described in RFC-4122)_.
 uuid(); // "52e6953d-edbe-4953-be2e-65ed3836b2f0"
 ```
 
-## `Math.getRandomValues()`
+### `Math.getRandomValues()`
 
 `Math.getRandomValues()` exposes an identical API to the
 [W3C `crypto.getRandomValues()`](https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues)
@@ -67,7 +67,7 @@ recommendation. With the same guarantees, regarding the quality of randomness:
 >
 > - [WebCryptoAPI 10.1. Description](https://www.w3.org/TR/WebCryptoAPI/#Crypto-description)
 
-`Math.getRandomValues()` will act as the foundation for implementing `UUID` algorithms, providing a
+`Math.getRandomValues()` will act as the foundation for implementing UUID algorithms, providing a
 single mockable (see [#25](https://github.com/tc39/proposal-uuid/issues/25)) source of randomness.
 
 ## Out of scope

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ developers from security pitfalls.
 
 ## Overview
 
+### UUID API
+
 The UUID standard library provides an API for generating RFC 4122 identifiers.
 
 The default export of the UUID library is the
@@ -51,8 +53,22 @@ representation _(as described in RFC-4122)_.
 uuid(); // "52e6953d-edbe-4953-be2e-65ed3836b2f0"
 ```
 
-All random values in UUIDs produced by this API must be generated from a **[cryptographically
-secure][csprng]** source.
+## `Math.getRandomValues()`
+
+`Math.getRandomValues()` exposes an identical API to the [W3C
+`crypto.getRandomValues()`][web-crypto#crypto-method-getrandomvalues] recommendation. With the same
+guarantees regarding the quality of randomness:
+
+> Implementations should generate cryptographically random values using well-established
+> cryptographic pseudo-random number generators seeded with high-quality entropy, such as from an
+> operating-system entropy source (e.g., "/dev/urandom"). This specification provides no
+> lower-bound on the information theoretic entropy present in cryptographically random values, but
+> implementations should make a best effort to provide as much entropy as practicable.
+>
+> - [WebCryptoAPI 10.1. Description][web-crypto#crypto-description]
+
+`Math.getRandomValues()` will act as the foundation for implementing `UUID` algorithms, providing a
+single mockable (see [#25](https://github.com/tc39/proposal-uuid/issues/25)) source of randomness.
 
 ## Out of scope
 
@@ -191,3 +207,4 @@ of a user account) so it's yet another reason to be very careful when choosing t
 [standard-library-proposal]: https://github.com/tc39/proposal-javascript-standard-library
 [tifu]: https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d
 [csprng]: https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator
+[web-crypto]: https://www.w3.org/TR/WebCryptoAPI/

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ uuid(); // "52e6953d-edbe-4953-be2e-65ed3836b2f0"
 
 ## `Math.getRandomValues()`
 
-`Math.getRandomValues()` exposes an identical API to the [W3C
-`crypto.getRandomValues()`][web-crypto#crypto-method-getrandomvalues] recommendation. With the same
-guarantees regarding the quality of randomness:
+`Math.getRandomValues()` exposes an identical API to the
+[W3C `crypto.getRandomValues()`](https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues)
+recommendation. With the same guarantees, regarding the quality of randomness:
 
 > Implementations should generate cryptographically random values using well-established
 > cryptographic pseudo-random number generators seeded with high-quality entropy, such as from an
@@ -65,7 +65,7 @@ guarantees regarding the quality of randomness:
 > lower-bound on the information theoretic entropy present in cryptographically random values, but
 > implementations should make a best effort to provide as much entropy as practicable.
 >
-> - [WebCryptoAPI 10.1. Description][web-crypto#crypto-description]
+> - [WebCryptoAPI 10.1. Description](https://www.w3.org/TR/WebCryptoAPI/#Crypto-description)
 
 `Math.getRandomValues()` will act as the foundation for implementing `UUID` algorithms, providing a
 single mockable (see [#25](https://github.com/tc39/proposal-uuid/issues/25)) source of randomness.
@@ -207,4 +207,3 @@ of a user account) so it's yet another reason to be very careful when choosing t
 [standard-library-proposal]: https://github.com/tc39/proposal-javascript-standard-library
 [tifu]: https://medium.com/@betable/tifu-by-using-math-random-f1c308c4fd9d
 [csprng]: https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator
-[web-crypto]: https://www.w3.org/TR/WebCryptoAPI/


### PR DESCRIPTION
Coming out of conversations in #25, and #31, I would like to advocate that the best option I've heard so far for facilitating the need for a mockable, secure source of randomness, _to act as a foundation for UUID algorithms_, would be the introduction of an API identical to `crypto.getRandomValues()`.

* this API is already [widely supported across major browsers](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues).
* and seems to exhibit the [traits we're looking for in generating secure UUIDs](https://www.w3.org/TR/WebCryptoAPI/#Crypto-description).

I'm looping in a couple fo the folks who have worked on the [Web Cryptography API](https://www.w3.org/TR/WebCryptoAPI), to see if they have any additional advice 😄 ....

~@mwatson~ (@mwatson2), @plehegar, to give you some context, we're working on a proposal to add cryptographically secure UUIDs to ECMAScript, and the idea has been floated that we use an API resembling `crypto.getRandomValues()` for the foundation of the algorithm.

see: #25, #31, #32 